### PR TITLE
Remove `wp-cli/snapshot-command`

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -50,7 +50,6 @@ github_repositories:
   - wp-cli/search-replace-command
   - wp-cli/server-command
   - wp-cli/shell-command
-  - wp-cli/snapshot-command
   - wp-cli/super-admin-command
   - wp-cli/widget-command
   - wp-cli/wp-cli


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli-dev/pull/49